### PR TITLE
Protect setText and allow contract owner change

### DIFF
--- a/HelloWorld.sol
+++ b/HelloWorld.sol
@@ -15,11 +15,15 @@ contract HelloWorld {
         textContent = _text;
     }
 
-    function setText(string memory _text) public {
+    function setText(string memory _text) onlyOwner public {
         textContent = _text;
     }
 
     function getText() public view returns (string memory) {
         return textContent;
+    }
+
+    function changeOwner(address newOwner) public {
+       owner = newOwner;
     }
 }


### PR DESCRIPTION
Limit setText function execution and only allows contract owner to call it.

Allow to change owner so that setText function could be called later by anybody who makes themselves as owners.